### PR TITLE
Split out RecordPatchRequest since form_id is not required or even PATCHable.

### DIFF
--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -2089,6 +2089,48 @@
           "record"
         ]
       },
+      "RecordPatchRequest": {
+        "type": "object",
+        "properties": {
+          "record": {
+            "type": "object",
+            "properties": {
+              "latitude": {
+                "type": "number",
+                "description": "Latitude coordinate"
+              },
+              "longitude": {
+                "type": "number",
+                "description": "Longitude coordinate"
+              },
+              "geometry": {
+                "$ref": "#/components/schemas/Geometry",
+                "description": "Optional GeoJSON geometry (Point, LineString, Polygon, MultiLineString, or MultiPolygon). If provided, latitude/longitude will be updated to reflect this geometry."
+              },
+              "form_values": {
+                "type": "object",
+                "description": "Field values keyed by field key",
+                "additionalProperties": true
+              },
+              "status": {
+                "type": "string",
+                "description": "Status of the record"
+              },
+              "project_id": {
+                "type": "string",
+                "description": "ID of the project"
+              },
+              "assigned_to_id": {
+                "type": "string",
+                "description": "ID of user assigned to this record"
+              }
+            }
+          }
+        },
+        "required": [
+          "record"
+        ]
+      },
       "ReportTemplateRequest": {
         "type": "object",
         "required": [
@@ -5536,7 +5578,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/RecordRequest"
+                "$ref": "#/components/schemas/RecordPatchRequest"
               }
             }
           }


### PR DESCRIPTION
Record Patch requests ignore form_id so take it out of the request schema.