### PR TITLE
Document the copy_all API endpoint for reference files (FLCRM-19499)

### DIFF
--- a/reference/ATTACHMENTS/_order.yaml
+++ b/reference/ATTACHMENTS/_order.yaml
@@ -3,4 +3,5 @@
 - get-single-attachment
 - create-attachment
 - finalize-attachment
+- copy-all-attachments
 - delete-attachment

--- a/reference/ATTACHMENTS/copy-all-attachments.md
+++ b/reference/ATTACHMENTS/copy-all-attachments.md
@@ -8,11 +8,11 @@ api:
 deprecated: false
 hidden: false
 metadata:
-  title: ""
-  description: ""
+  title: ''
+  description: ''
   robots: noindex
 next:
-  description: ""
+  description: ''
 ---
 
 This endpoint allows you to copy all reference files from a source form to a destination form. This is useful when cloning a form or moving reference data between applications.

--- a/reference/ATTACHMENTS/copy-all-attachments.md
+++ b/reference/ATTACHMENTS/copy-all-attachments.md
@@ -1,0 +1,23 @@
+---
+title: Copy All Reference Files
+excerpt: >-
+  Copy all reference files from one form to another.
+api:
+  file: rest-api.json
+  operationId: copy-all-attachments
+deprecated: false
+hidden: false
+metadata:
+  title: ""
+  description: ""
+  robots: noindex
+next:
+  description: ""
+---
+
+This endpoint allows you to copy all reference files from a source form to a destination form.
+
+# Limits
+
+- **100 reference files** per form.
+- **1GB** total reference file size per form.

--- a/reference/ATTACHMENTS/copy-all-attachments.md
+++ b/reference/ATTACHMENTS/copy-all-attachments.md
@@ -15,7 +15,29 @@ next:
   description: ""
 ---
 
-This endpoint allows you to copy all reference files from a source form to a destination form.
+This endpoint allows you to copy all reference files from a source form to a destination form. This is useful when cloning a form or moving reference data between applications.
+
+# Request Payload
+
+```json
+{
+  "source_parent_id": "93eb5194-472e-436f-8769-6554b5f8845c",
+  "destination_parent_id": "842d5194-472e-436f-8769-6554b5f8845c",
+  "parent_type": "form"
+}
+```
+
+# Response
+
+The response includes a mapping of the original attachment IDs to the new attachment IDs created during the copy process.
+
+```json
+{
+  "ref_file_mapping": {
+    "ef9bc6b0-cfd2-4c3a-8189-316f1335126a": "694e1ea7-f847-4fe3-a8bb-299c50e0e6ed"
+  }
+}
+```
 
 # Limits
 

--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -10285,10 +10285,36 @@
               }
             }
           },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": "{\n  \"error\": \"Bad Request\"\n}"
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Bad Request"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "description": "Unauthorized",
             "content": {
               "application/json": {
+                "examples": {
+                  "Result": {
+                    "value": "{\n  \"error\": \"Unauthorized\"\n}"
+                  }
+                },
                 "schema": {
                   "type": "object",
                   "properties": {

--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -10307,7 +10307,7 @@
             }
           },
           "401": {
-            "description": "Unauthorized",
+            "description": "401",
             "content": {
               "application/json": {
                 "examples": {

--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -518,6 +518,7 @@
           "destination_parent_id",
           "parent_type"
         ],
+        "additionalProperties": false,
         "properties": {
           "source_parent_id": {
             "type": "string",
@@ -10301,7 +10302,8 @@
               }
             }
           }
-        }
+        },
+        "deprecated": false
       }
     },
     "/v2/attachments/finalize": {

--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -10259,7 +10259,6 @@
             "name": "x-apitoken",
             "in": "header",
             "description": "API Token. Required to authenticate the request.",
-            "required": true,
             "schema": {
               "type": "string"
             }

--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -10255,7 +10255,7 @@
         "operationId": "copy-all-attachments",
         "parameters": [
           {
-            "name": "X-ApiToken",
+            "name": "x-apitoken",
             "in": "header",
             "description": "API Token. Required to authenticate the request.",
             "required": true,
@@ -10281,6 +10281,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AttachmentCopyAllResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Unauthorized"
+                    }
+                  }
                 }
               }
             }

--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -511,6 +511,43 @@
         },
         "description": "Location metadata captured at creation or update time."
       },
+      "AttachmentCopyAllRequest": {
+        "type": "object",
+        "required": [
+          "source_parent_id",
+          "destination_parent_id",
+          "parent_type"
+        ],
+        "properties": {
+          "source_parent_id": {
+            "type": "string",
+            "description": "The ID of the source parent (e.g. form ID) to copy reference files from"
+          },
+          "destination_parent_id": {
+            "type": "string",
+            "description": "The ID of the destination parent (e.g. form ID) to copy reference files to"
+          },
+          "parent_type": {
+            "type": "string",
+            "description": "The type of the parent resource",
+            "enum": [
+              "form"
+            ]
+          }
+        }
+      },
+      "AttachmentCopyAllResponse": {
+        "type": "object",
+        "properties": {
+          "ref_file_mapping": {
+            "type": "object",
+            "description": "A mapping of original reference file attachment IDs to their new copies",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "AttachmentCreateRequest": {
         "type": "object",
         "required": [
@@ -10209,6 +10246,46 @@
           }
         },
         "deprecated": false
+      }
+    },
+    "/v2/attachments/copy_all": {
+      "post": {
+        "summary": "Copy all reference files",
+        "description": "Copy all reference files from one form to another. Limits: 100 reference files per form, 1GB total per form.",
+        "operationId": "copy-all-attachments",
+        "parameters": [
+          {
+            "name": "X-ApiToken",
+            "in": "header",
+            "description": "API Token. Required to authenticate the request.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttachmentCopyAllRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttachmentCopyAllResponse"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v2/attachments/finalize": {


### PR DESCRIPTION
## Description
This PR documents the new `copy_all` API endpoint for copying reference files between forms, as requested in [FLCRM-19499](https://fulcrumapp.atlassian.net/browse/FLCRM-19499).

### Changes:
- Added `AttachmentCopyAllRequest` and `AttachmentCopyAllResponse` schemas to `rest-api.json`.
- Defined the `POST /v2/attachments/copy_all` endpoint in `rest-api.json`.
- Created a new documentation page `copy-all-attachments.md` details the endpoint and its current limits (100 files / form, 1GB / form).
- Updated `_order.yaml` to include the new endpoint in the Attachments API documentation.

### Limits:
- 100 reference files per form.
- 1GB total per form.

[FLCRM-19499]: https://fulcrumapp.atlassian.net/browse/FLCRM-19499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ