### PR TITLE
Remove video demo from rich text editor documentation

### DIFF
--- a/docs/App Extensions/app-extension-examples/rich-text-editor.md
+++ b/docs/App Extensions/app-extension-examples/rich-text-editor.md
@@ -20,13 +20,6 @@ Use this when you want report-ready formatting such as headings, lists, links, e
 ## Demo Clip
 Watch a short clip of the extension workflow:
 
-```html
-<video controls playsinline style="width:100%;max-width:960px;border-radius:8px;">
-  <source src="https://reportassets.fulcrumapp.com/readme-assets/rich-text-editor-clip.mp4" type="video/mp4" />
-  Your browser does not support embedded video.
-</video>
-```
-
 [Download clip: rich-text-editor-clip.mp4](https://reportassets.fulcrumapp.com/readme-assets/rich-text-editor-clip.mp4)
 
 What this clip shows:


### PR DESCRIPTION
Removed embedded video HTML and download link from the rich text editor documentation.