### PR TITLE
Update AttachmentCreateRequest schema properties

### DIFF
--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -550,56 +550,48 @@
         }
       },
       "AttachmentCreateRequest": {
-        "type": "object",
-        "required": [
-          "attachment"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "attachment": {
+      "type": "object",
+      "required": [
+        "owners"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "owners": {
+          "type": "array",
+          "description": "Array of owner objects for the attachment",
+          "items": {
             "type": "object",
             "required": [
-              "owners"
+              "type",
+              "id"
             ],
             "properties": {
-              "owners": {
-                "type": "array",
-                "description": "Array of owner objects for the attachment",
-                "items": {
-                  "type": "object",
-                  "required": [
-                    "type",
-                    "id"
-                  ],
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "description": "Type of the owner (e.g., 'record', 'form')"
-                    },
-                    "id": {
-                      "type": "string",
-                      "description": "Identifier of the owner"
-                    }
-                  }
-                }
-              },
-              "name": {
+              "type": {
                 "type": "string",
-                "description": "Name of the attachment"
+                "description": "Type of the owner (e.g., 'record', 'form')"
               },
-              "file_size": {
-                "type": "integer",
-                "description": "Size of the file in bytes"
-              },
-              "metadata": {
-                "type": "object",
-                "description": "Optional metadata for the attachment",
-                "additionalProperties": true
+              "id": {
+                "type": "string",
+                "description": "Identifier of the owner"
               }
             }
           }
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the attachment"
+        },
+        "file_size": {
+          "type": "integer",
+          "description": "Size of the file in bytes"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "Optional metadata for the attachment",
+          "additionalProperties": true
         }
-      },
+      }
+    },
       "AttachmentTrackRequest": {
         "type": "object",
         "required": [


### PR DESCRIPTION
The support team has noticed that the Create Attachment properties on the docs page are wrong. The attachment {} object should not be part of the request. The endpoint expects owners [] as parent of the object.