### PR TITLE
[FLCRM-20332] add new sketch attributes to forms api docs

### DIFF
--- a/reference/FORMS/forms-intro.md
+++ b/reference/FORMS/forms-intro.md
@@ -188,11 +188,14 @@ Associate audio recordings with this field by launching the microphone or select
 
 Associate sketches with this field by drawing on a canvas with an optional background. Each Sketch field allows any number of sketches to be added to it.
 
-| Property    | Type   | Required | Description                        |
-| ----------- | ------ | -------- | ---------------------------------- |
-| backgrounds | array  | no       | Array of background image objects. |
-| min\_length | number | no       | Minimum number of sketches.        |
-| max\_length | number | no       | Maximum number of sketches.        |
+| Property                      | Type    | Required | Description                                                                 |
+| ----------------------------- | ------- | -------- | --------------------------------------------------------------------------- |
+| backgrounds                   | array   | no       | Array of background image objects.                                          |
+| min\_length                   | number  | no       | Minimum number of sketches.                                                 |
+| max\_length                   | number  | no       | Maximum number of sketches.                                                 |
+| map\_background\_enabled      | boolean | no       | Enable map background option for sketches. Defaults to `false`.             |
+| blank\_canvas\_enabled        | boolean | no       | Enable blank canvas option for sketches. Defaults to `true`.                |
+| custom\_background\_enabled   | boolean | no       | Enable custom background image option for sketches. Defaults to `false`.    |
 
 ## Section
 


### PR DESCRIPTION
# Add New Sketch Attributes to Forms API Docs

**Branch:** `task/FLCRM-20332-add-new-sketch-attributes-to-forms-api-docs`  
**Base:** `v2`  
**Ticket:** FLCRM-20332  

## Summary

This PR adds three new boolean properties to the **SketchField** documentation in the Forms API reference. These properties control which background options are available when creating sketches.

## Changed Files

### `reference/FORMS/forms-intro.md`

**Section:** SketchField

Added the following new properties to the SketchField property table:

| Property                    | Type    | Required | Default | Description                                          |
| --------------------------- | ------- | -------- | ------- | ---------------------------------------------------- |
| `map_background_enabled`    | boolean | no       | `false` | Enable map background option for sketches.           |
| `blank_canvas_enabled`      | boolean | no       | `true`  | Enable blank canvas option for sketches.             |
| `custom_background_enabled` | boolean | no       | `false` | Enable custom background image option for sketches.  |

### Before

The SketchField table only included:

- `backgrounds` — Array of background image objects.
- `min_length` — Minimum number of sketches.
- `max_length` — Maximum number of sketches.

### After

The SketchField table now includes the three original properties plus the three new boolean properties listed above, giving API consumers visibility into the sketch background configuration options.