### PR TITLE
fix: Add typed FormElement schemas and document YesNoField requirements

### DIFF
--- a/reference/FORMS/forms-intro.md
+++ b/reference/FORMS/forms-intro.md
@@ -128,7 +128,7 @@ For simple yes/no questions with optional neutral state.
 | neutral\_enabled         | boolean | yes                 | Enable N/A choice?                                                   |
 | neutral                  | object  | if neutral\_enabled | Label/Value for neutral choice (`{"label": "N/A","value": "n/a"}`).  |
 | positive                 | object  | yes                 | Label/Value for positive choice (`{"label": "Yes","value": "yes"}`). |
-| negative                 | object  | yes                 | Label/Value for positive choice (`{"label": "No","value": "no"}`).   |
+| negative                 | object  | yes                 | Label/Value for negative choice (`{"label": "No","value": "no"}`).   |
 | default\_previous\_value | boolean | `false`             | Whether to automatically set the previously used value.              |
 
 ## ChoiceField

--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -1895,11 +1895,205 @@
           }
         }
       },
+      "FormElementChoice": {
+        "type": "object",
+        "description": "A selectable choice option for ChoiceField elements",
+        "required": ["label", "value"],
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Display label shown to the user"
+          },
+          "value": {
+            "type": "string",
+            "description": "Stored value in the database"
+          }
+        }
+      },
+      "YesNoLabelValue": {
+        "type": "object",
+        "description": "Label/value pair for YesNoField positive, negative, or neutral options",
+        "required": ["label", "value"],
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Display label (e.g. Yes, No, N/A)"
+          },
+          "value": {
+            "type": "string",
+            "description": "Stored value (e.g. yes, no, n/a)"
+          }
+        }
+      },
+      "FormElement": {
+        "type": "object",
+        "description": "A form field or section element. All elements share common required properties. Additional properties vary by field type — see the Forms reference documentation for type-specific properties.",
+        "required": ["type", "key", "label", "data_name", "required", "disabled", "hidden"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Field type identifier",
+            "enum": [
+              "TextField",
+              "YesNoField",
+              "Label",
+              "Section",
+              "ChoiceField",
+              "ClassificationField",
+              "PhotoField",
+              "VideoField",
+              "AudioField",
+              "SketchField",
+              "BarcodeField",
+              "DateTimeField",
+              "TimeField",
+              "Repeatable",
+              "AddressField",
+              "SignatureField",
+              "HyperlinkField",
+              "CalculatedField",
+              "RecordLinkField"
+            ]
+          },
+          "key": {
+            "type": "string",
+            "description": "Unique field key within the form. Must be lowercase. The Fulcrum app builder uses 4-character codes."
+          },
+          "label": {
+            "type": "string",
+            "description": "Display label visible to users"
+          },
+          "data_name": {
+            "type": "string",
+            "description": "Programmatic name used in form_values, exports, and queries. Recommended to keep under 10 characters for Shapefile compatibility."
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Whether the field is required"
+          },
+          "disabled": {
+            "type": "boolean",
+            "description": "Whether the field is read-only"
+          },
+          "hidden": {
+            "type": "boolean",
+            "description": "Whether the field is hidden on mobile"
+          },
+          "default_value": {
+            "description": "Default value for the field. Required for non-Section types.",
+            "oneOf": [
+              {"type": "string"},
+              {"type": "null"}
+            ]
+          },
+          "description": {
+            "type": "string",
+            "description": "Helper text shown below the field"
+          },
+          "visible_conditions_type": {
+            "type": "string",
+            "enum": ["all", "any"],
+            "description": "Match all or any conditions to display this field"
+          },
+          "visible_conditions": {
+            "type": "array",
+            "description": "Visibility conditions",
+            "items": {"type": "object"}
+          },
+          "required_conditions_type": {
+            "type": "string",
+            "enum": ["all", "any"],
+            "description": "Match all or any conditions to require this field"
+          },
+          "required_conditions": {
+            "type": "array",
+            "description": "Requirement conditions",
+            "items": {"type": "object"}
+          },
+          "default_previous_value": {
+            "type": "boolean",
+            "description": "Whether to automatically set the previously used value"
+          },
+          "choices": {
+            "type": "array",
+            "description": "Inline choices for ChoiceField elements",
+            "items": {
+              "$ref": "#/components/schemas/FormElementChoice"
+            }
+          },
+          "positive": {
+            "$ref": "#/components/schemas/YesNoLabelValue",
+            "description": "Required for YesNoField. Label/value for the positive (Yes) choice. Example: {\"label\": \"Yes\", \"value\": \"yes\"}"
+          },
+          "negative": {
+            "$ref": "#/components/schemas/YesNoLabelValue",
+            "description": "Required for YesNoField. Label/value for the negative (No) choice. Example: {\"label\": \"No\", \"value\": \"no\"}"
+          },
+          "neutral_enabled": {
+            "type": "boolean",
+            "description": "Required for YesNoField. Whether the N/A option is enabled."
+          },
+          "neutral": {
+            "$ref": "#/components/schemas/YesNoLabelValue",
+            "description": "Required for YesNoField when neutral_enabled is true. Label/value for the neutral (N/A) choice."
+          },
+          "elements": {
+            "type": "array",
+            "description": "Child elements for Section and Repeatable types",
+            "items": {
+              "$ref": "#/components/schemas/FormElement"
+            }
+          },
+          "display": {
+            "type": "string",
+            "enum": ["inline", "drilldown"],
+            "description": "Display type for Section elements"
+          },
+          "numeric": {
+            "type": "boolean",
+            "description": "TextField: restrict to numeric input"
+          },
+          "pattern": {
+            "type": "string",
+            "description": "TextField: regex pattern for validation"
+          },
+          "min_length": {
+            "type": "integer",
+            "description": "Minimum length (text) or minimum count (photos/videos/audio/sketches)"
+          },
+          "max_length": {
+            "type": "integer",
+            "description": "Maximum length (text) or maximum count (photos/videos/audio/sketches)"
+          },
+          "multiple": {
+            "type": "boolean",
+            "description": "ChoiceField: allow multiple selections"
+          },
+          "allow_other": {
+            "type": "boolean",
+            "description": "ChoiceField/ClassificationField: allow free-text Other option"
+          },
+          "choice_list_id": {
+            "type": "string",
+            "description": "ChoiceField: ID of a shared choice list"
+          },
+          "classification_set_id": {
+            "type": "string",
+            "description": "ClassificationField: ID of the classification set (required for ClassificationField)"
+          },
+          "expression": {
+            "type": "string",
+            "description": "CalculatedField: calculation expression"
+          }
+        }
+      },
       "FormRequest": {
         "type": "object",
+        "required": ["form"],
         "properties": {
           "form": {
             "type": "object",
+            "required": ["name", "elements"],
             "properties": {
               "name": {
                 "type": "string",
@@ -1911,17 +2105,129 @@
               },
               "elements": {
                 "type": "array",
-                "description": "Form elements/fields",
+                "description": "Form elements (fields and sections). See FormElement schema for required properties per field type.",
                 "items": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/FormElement"
+                }
+              },
+              "status_field": {
+                "type": "object",
+                "description": "Status field configuration. See Forms reference for properties."
+              },
+              "geometry_types": {
+                "type": "array",
+                "description": "Geometry types: Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "auto_assign": {
+                "type": "boolean",
+                "description": "Assign records to the creating user"
+              },
+              "projects_enabled": {
+                "type": "boolean",
+                "description": "Enable projects for this form"
+              },
+              "assignment_enabled": {
+                "type": "boolean",
+                "description": "Enable record assignment"
+              },
+              "title_field_keys": {
+                "type": "array",
+                "description": "Field keys used to generate record titles",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "script": {
+                "type": "string",
+                "description": "Custom Data Events script"
+              }
+            }
+          }
+        }
+      },
+      "FormResponse": {
+        "type": "object",
+        "description": "Response containing a single form object",
+        "properties": {
+          "form": {
+            "type": "object",
+            "description": "The form object with all properties and metadata",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Unique form ID"
+              },
+              "name": {
+                "type": "string",
+                "description": "Form name"
+              },
+              "description": {
+                "type": "string",
+                "description": "Form description"
+              },
+              "elements": {
+                "type": "array",
+                "description": "Form elements",
+                "items": {
+                  "$ref": "#/components/schemas/FormElement"
+                }
+              },
+              "status_field": {
+                "type": "object",
+                "description": "Status field configuration"
+              },
+              "record_count": {
+                "type": "integer",
+                "description": "Number of records in this form"
+              },
+              "created_at": {
+                "type": "string",
+                "description": "ISO 8601 creation timestamp"
+              },
+              "updated_at": {
+                "type": "string",
+                "description": "ISO 8601 last update timestamp"
+              },
+              "geometry_types": {
+                "type": "array",
+                "items": {"type": "string"}
+              },
+              "auto_assign": {
+                "type": "boolean"
+              },
+              "projects_enabled": {
+                "type": "boolean"
+              },
+              "assignment_enabled": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "FormValidationErrorResponse": {
+        "type": "object",
+        "description": "Validation error response for form create/update. Returns nested error messages per field.",
+        "properties": {
+          "form": {
+            "type": "object",
+            "properties": {
+              "errors": {
+                "type": "object",
+                "description": "Map of field names to arrays of error messages",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               }
             }
           }
-        },
-        "required": [
-          "form"
-        ]
+        }
       },
       "GroupCreateRequest": {
         "type": "object",
@@ -4590,22 +4896,22 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "Success",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/EmptySuccessResponse"
+                  "$ref": "#/components/schemas/FormResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
+          "422": {
+            "description": "Unprocessable Entity — validation errors (e.g. missing required element properties like disabled, hidden, required). Note: some element validation failures (e.g. YesNoField missing positive/negative) may incorrectly return 500 instead of 422.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BadRequestResponse"
+                  "$ref": "#/components/schemas/FormValidationErrorResponse"
                 }
               }
             }
@@ -4717,17 +5023,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/EmptySuccessResponse"
+                  "$ref": "#/components/schemas/FormResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
+          "422": {
+            "description": "Unprocessable Entity — validation errors",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BadRequestResponse"
+                  "$ref": "#/components/schemas/FormValidationErrorResponse"
                 }
               }
             }

--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -1925,9 +1925,83 @@
           }
         }
       },
+      "CalculatedFieldDisplay": {
+        "type": "object",
+        "description": "Display formatting for CalculatedField elements",
+        "required": ["style"],
+        "properties": {
+          "style": {
+            "type": "string",
+            "description": "Calculated value display style",
+            "enum": ["number", "currency", "date", "string"]
+          },
+          "currency": {
+            "type": "string",
+            "description": "ISO 4217 currency code. Required when style is currency."
+          }
+        }
+      },
+      "StatusFieldChoice": {
+        "type": "object",
+        "description": "A selectable status value for a form status field",
+        "required": ["label", "value"],
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "Display label shown to the user"
+          },
+          "value": {
+            "type": "string",
+            "description": "Stored status value"
+          },
+          "color": {
+            "type": "string",
+            "description": "Status color as a hex value, usually with a leading #"
+          }
+        }
+      },
+      "StatusField": {
+        "type": "object",
+        "description": "Status field configuration for a form",
+        "required": ["type", "label", "data_name"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["StatusField"],
+            "description": "Status field type identifier"
+          },
+          "key": {
+            "type": "string",
+            "description": "Status field key"
+          },
+          "label": {
+            "type": "string",
+            "description": "Display label visible to users"
+          },
+          "data_name": {
+            "type": "string",
+            "description": "Programmatic status field name"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the status field is enabled"
+          },
+          "default_value": {
+            "type": "string",
+            "description": "Default status value"
+          },
+          "choices": {
+            "type": "array",
+            "description": "Available status choices",
+            "items": {
+              "$ref": "#/components/schemas/StatusFieldChoice"
+            }
+          }
+        }
+      },
       "FormElement": {
         "type": "object",
-        "description": "A form field or section element. All elements share common required properties. Additional properties vary by field type — see the Forms reference documentation for type-specific properties.",
+        "description": "A form field or section element. Field type names are sourced from fulcrum-schema data elements plus layout-only Section and Label elements. Additional properties vary by field type — see the Forms reference documentation for type-specific properties.",
         "required": ["type", "key", "label", "data_name", "required", "disabled", "hidden"],
         "properties": {
           "type": {
@@ -1943,6 +2017,7 @@
               "PhotoField",
               "VideoField",
               "AudioField",
+              "AttachmentField",
               "SketchField",
               "BarcodeField",
               "DateTimeField",
@@ -1952,7 +2027,11 @@
               "SignatureField",
               "HyperlinkField",
               "CalculatedField",
-              "RecordLinkField"
+              "RecordLinkField",
+              "CheckboxField",
+              "DynamicField",
+              "LocationField",
+              "ButtonField"
             ]
           },
           "key": {
@@ -1980,11 +2059,10 @@
             "description": "Whether the field is hidden on mobile"
           },
           "default_value": {
-            "description": "Default value for the field. Required for non-Section types.",
-            "oneOf": [
-              {"type": "string"},
-              {"type": "null"}
-            ]
+            "description": "Default value for the field. Shape varies by field type and may be string, number, boolean, array, object, or null. Required for non-Section types."
+          },
+          "default_values": {
+            "description": "Default values for field types that store multiple values. Shape varies by field type and may be array, object, or null."
           },
           "description": {
             "type": "string",
@@ -2045,9 +2123,19 @@
             }
           },
           "display": {
-            "type": "string",
-            "enum": ["inline", "drilldown"],
-            "description": "Display type for Section elements"
+            "description": "Display configuration. Section elements use a string (inline or drilldown). CalculatedField elements use an object with style and optional currency.",
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": ["inline", "drilldown"]
+              },
+              {
+                "$ref": "#/components/schemas/CalculatedFieldDisplay"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "numeric": {
             "type": "boolean",
@@ -2081,6 +2169,26 @@
             "type": "string",
             "description": "ClassificationField: ID of the classification set (required for ClassificationField)"
           },
+          "record_link_form_id": {
+            "type": "string",
+            "description": "RecordLinkField: ID of the linked form"
+          },
+          "record_link_default_field_key": {
+            "type": "string",
+            "description": "RecordLinkField: key of the linked form field to display by default"
+          },
+          "agreement_text": {
+            "type": "string",
+            "description": "SignatureField: agreement text shown above the signature pad"
+          },
+          "default_url": {
+            "type": "string",
+            "description": "HyperlinkField: default URL value"
+          },
+          "auto_populate": {
+            "type": "boolean",
+            "description": "AddressField/LocationField: automatically populate from GPS or device location"
+          },
           "expression": {
             "type": "string",
             "description": "CalculatedField: calculation expression"
@@ -2111,8 +2219,7 @@
                 }
               },
               "status_field": {
-                "type": "object",
-                "description": "Status field configuration. See Forms reference for properties."
+                "$ref": "#/components/schemas/StatusField"
               },
               "geometry_types": {
                 "type": "array",
@@ -2176,8 +2283,7 @@
                 }
               },
               "status_field": {
-                "type": "object",
-                "description": "Status field configuration"
+                "$ref": "#/components/schemas/StatusField"
               },
               "record_count": {
                 "type": "integer",

--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -2783,7 +2783,7 @@
                 "type": "string",
                 "enum": [
                   "advanced",
-                  "simple"
+                  "basic"
                 ],
                 "description": "The type of the report template"
               },
@@ -2811,15 +2811,7 @@
                 "properties": {
                   "size": {
                     "type": "string",
-                    "enum": [
-                      "Letter",
-                      "Legal",
-                      "Tabloid",
-                      "Ledger",
-                      "A3",
-                      "A4"
-                    ],
-                    "description": "Page size for the report"
+                    "description": "Page size for the report. Accepts Letter, Legal, Tabloid, Ledger, A0-A8, B0-B10, or custom sizes in WIDTHxHEIGHT format."
                   },
                   "landscape": {
                     "type": "boolean",
@@ -2844,8 +2836,8 @@
                   "output": {
                     "type": "string",
                     "enum": [
-                      "pdf",
-                      "docx"
+                      "html",
+                      "pdf"
                     ],
                     "description": "Output format"
                   },
@@ -2975,10 +2967,12 @@
                       "type": "object",
                       "required": [
                         "name",
-                        "label",
                         "type",
                         "required",
-                        "multiple"
+                        "multiple",
+                        "options",
+                        "query",
+                        "default"
                       ],
                       "properties": {
                         "name": {
@@ -3011,13 +3005,13 @@
                           "description": "Whether multiple values are allowed"
                         },
                         "options": {
-                          "description": "Available options for the parameter - can be array, object, or null"
+                          "description": "Available options for the parameter. The API accepts an array or null."
                         },
                         "query": {
-                          "description": "Query to filter available options - can be string, object, or null"
+                          "description": "Query to filter available options. The API accepts a string or null."
                         },
                         "default": {
-                          "description": "Default value(s) for the parameter - can be any type"
+                          "description": "Default value(s) for the parameter. The API accepts an array or null."
                         }
                       }
                     }
@@ -3025,6 +3019,138 @@
                 }
               }
             }
+          }
+        }
+      },
+      "ReportTemplate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the report template"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the report template"
+          },
+          "description": {
+            "type": "string",
+            "description": "A description of the report template"
+          },
+          "body": {
+            "type": "string",
+            "description": "The HTML/EJS template for the report body"
+          },
+          "header": {
+            "type": "string",
+            "description": "The HTML/EJS template for the report header"
+          },
+          "filename_pattern": {
+            "type": "string",
+            "description": "Pattern for generating report filenames"
+          },
+          "footer": {
+            "type": "string",
+            "description": "The HTML/EJS template for the report footer"
+          },
+          "styles": {
+            "type": "string",
+            "description": "CSS styles for the report"
+          },
+          "script": {
+            "type": "string",
+            "description": "JavaScript code for the report"
+          },
+          "config": {
+            "type": "object",
+            "description": "Configuration settings for the report",
+            "additionalProperties": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "inactive"
+            ],
+            "description": "The status of the report template"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "advanced",
+              "basic"
+            ],
+            "description": "The type of the report template"
+          },
+          "form_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The ID of the form this report template is associated with"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the report template was created"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the report template was last updated"
+          },
+          "created_by": {
+            "type": "string",
+            "description": "Display name of the user who created the report template"
+          },
+          "created_by_id": {
+            "type": "string",
+            "description": "ID of the user who created the report template"
+          },
+          "updated_by": {
+            "type": "string",
+            "description": "Display name of the user who last updated the report template"
+          },
+          "updated_by_id": {
+            "type": "string",
+            "description": "ID of the user who last updated the report template"
+          }
+        }
+      },
+      "ReportTemplateResponse": {
+        "type": "object",
+        "required": [
+          "report_template"
+        ],
+        "properties": {
+          "report_template": {
+            "$ref": "#/components/schemas/ReportTemplate"
+          }
+        }
+      },
+      "ReportTemplatesResponse": {
+        "type": "object",
+        "required": [
+          "report_templates"
+        ],
+        "properties": {
+          "report_templates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReportTemplate"
+            }
+          },
+          "current_page": {
+            "type": "integer"
+          },
+          "total_pages": {
+            "type": "integer"
+          },
+          "total_count": {
+            "type": "integer"
+          },
+          "per_page": {
+            "type": "integer"
           }
         }
       },
@@ -12364,7 +12490,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/EmptySuccessResponse"
+                  "$ref": "#/components/schemas/ReportTemplatesResponse"
                 }
               }
             }
@@ -12396,12 +12522,12 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "Success",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/EmptySuccessResponse"
+                  "$ref": "#/components/schemas/ReportTemplateResponse"
                 }
               }
             }
@@ -12442,7 +12568,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/EmptySuccessResponse"
+                  "$ref": "#/components/schemas/ReportTemplateResponse"
                 }
               }
             }
@@ -12490,7 +12616,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/EmptySuccessResponse"
+                  "$ref": "#/components/schemas/ReportTemplateResponse"
                 }
               }
             }
@@ -12529,7 +12655,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/EmptySuccessResponse"
+                  "$ref": "#/components/schemas/ReportTemplateResponse"
                 }
               }
             }

--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -2084,9 +2084,14 @@
             ]
           },
           "visible_conditions": {
-            "type": "array",
             "description": "Visibility conditions",
-            "items": {"type": "object"}
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {"type": "object"}
+              },
+              {"type": "null"}
+            ]
           },
           "required_conditions_type": {
             "description": "Match all or any conditions to require this field",

--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -2089,9 +2089,16 @@
             "items": {"type": "object"}
           },
           "required_conditions_type": {
-            "type": "string",
-            "enum": ["all", "any"],
-            "description": "Match all or any conditions to require this field"
+            "description": "Match all or any conditions to require this field",
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": ["all", "any"]
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "required_conditions": {
             "type": "array",

--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -2294,10 +2294,12 @@
               },
               "created_at": {
                 "type": "string",
+                "format": "date-time",
                 "description": "ISO 8601 creation timestamp"
               },
               "updated_at": {
                 "type": "string",
+                "format": "date-time",
                 "description": "ISO 8601 last update timestamp"
               },
               "geometry_types": {

--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -2065,7 +2065,10 @@
             "description": "Default values for field types that store multiple values. Shape varies by field type and may be array, object, or null."
           },
           "description": {
-            "type": "string",
+            "oneOf": [
+              {"type": "string"},
+              {"type": "null"}
+            ],
             "description": "Helper text shown below the field"
           },
           "visible_conditions_type": {

--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -2023,19 +2023,19 @@
           },
           "positive": {
             "$ref": "#/components/schemas/YesNoLabelValue",
-            "description": "Required for YesNoField. Label/value for the positive (Yes) choice. Example: {\"label\": \"Yes\", \"value\": \"yes\"}"
+            "description": "Applicable to YesNoField. Label/value for the positive (Yes) choice. Example: {\"label\": \"Yes\", \"value\": \"yes\"}"
           },
           "negative": {
             "$ref": "#/components/schemas/YesNoLabelValue",
-            "description": "Required for YesNoField. Label/value for the negative (No) choice. Example: {\"label\": \"No\", \"value\": \"no\"}"
+            "description": "Applicable to YesNoField. Label/value for the negative (No) choice. Example: {\"label\": \"No\", \"value\": \"no\"}"
           },
           "neutral_enabled": {
             "type": "boolean",
-            "description": "Required for YesNoField. Whether the N/A option is enabled."
+            "description": "Applicable to YesNoField. Whether the N/A option is enabled."
           },
           "neutral": {
             "$ref": "#/components/schemas/YesNoLabelValue",
-            "description": "Required for YesNoField when neutral_enabled is true. Label/value for the neutral (N/A) choice."
+            "description": "Applicable to YesNoField when neutral_enabled is true. Label/value for the neutral (N/A) choice."
           },
           "elements": {
             "type": "array",

--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -2283,7 +2283,8 @@
         "properties": {
           "form": {
             "type": "object",
-            "description": "The form object with all properties and metadata",
+            "description": "The form object with common properties and metadata. Additional form properties may also be returned by the API.",
+            "additionalProperties": true,
             "properties": {
               "id": {
                 "type": "string",

--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -2072,9 +2072,16 @@
             "description": "Helper text shown below the field"
           },
           "visible_conditions_type": {
-            "type": "string",
-            "enum": ["all", "any"],
-            "description": "Match all or any conditions to display this field"
+            "description": "Match all or any conditions to display this field",
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": ["all", "any"]
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "visible_conditions": {
             "type": "array",


### PR DESCRIPTION
## Summary

While building MCP server tooling that creates forms via the Fulcrum API, I discovered several gaps in the OpenAPI spec that made it difficult to build correct API clients.

## Changes

### OpenAPI schema improvements (`reference/rest-api.json`)

**New schemas added:**
- **`FormElement`** — comprehensive typed schema for form elements covering all 19 field types with their type-specific properties (`positive`/`negative`/`neutral_enabled` for YesNoField, `choices`/`multiple`/`allow_other` for ChoiceField, `elements` for Section/Repeatable, `expression` for CalculatedField, etc.)
- **`FormElementChoice`** — reusable label/value pair for ChoiceField choices
- **`YesNoLabelValue`** — reusable label/value pair for YesNoField positive/negative/neutral
- **`FormResponse`** — response schema for forms create/update (the API returns the full form object, not an empty response)
- **`FormValidationErrorResponse`** — error response schema for 422 validation errors (nested `form.errors` format)

**Existing schema improvements:**
- **`FormRequest`** — `elements` was typed as `array of {"type": "object"}` (completely untyped). Now references the new `FormElement` schema. Added `required` constraint on `name` and `elements`. Added additional form-level properties (`status_field`, `geometry_types`, `auto_assign`, `projects_enabled`, `assignment_enabled`, `title_field_keys`, `script`)

**Endpoint corrections:**
- **forms-create** — Response changed from `200 EmptySuccessResponse` to `201 FormResponse` (the API actually returns 201 with the created form). Added `422` response with `FormValidationErrorResponse`
- **forms-update** — Response changed from `EmptySuccessResponse` to `FormResponse`. Added `422` response

### Documentation improvements (`reference/FORMS/forms-intro.md`)

- Added warning callout to YesNoField section: omitting `positive`/`negative`/`neutral_enabled` causes a **500 Internal Server Error** instead of a 422 validation error
- Added minimal YesNoField JSON example showing all required properties
- Fixed typo: `negative` property description incorrectly said "positive choice"

## Context

These issues were discovered while building [fulcrum-app-mcp](https://github.com/fulcrumapp/fulcrum-app-mcp), which uses the Fulcrum API to create forms programmatically. The untyped `elements` array and missing YesNoField documentation led to multiple bugs that were difficult to diagnose:

1. Fields created without `disabled`/`hidden`/`required` → 422 with unhelpful error messages
2. YesNoField created without `positive`/`negative` → 500 Internal Server Error (no error message at all)
3. Form create response was documented as empty but actually returns the full form object