### PR TITLE
fix: align OpenAPI spec with live API behavior

### DIFF
--- a/reference/rest-api.json
+++ b/reference/rest-api.json
@@ -595,40 +595,31 @@
       "AttachmentTrackRequest": {
         "type": "object",
         "required": [
-          "attachment"
+          "id"
         ],
         "additionalProperties": false,
         "properties": {
-          "attachment": {
-            "type": "object",
-            "required": [
-              "id"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "id": {
-                "type": "string",
-                "description": "Identifier of the attachment"
-              },
-              "owners": {
-                "type": "array",
-                "description": "Array of owner objects for the attachment",
-                "items": {
-                  "type": "object",
-                  "required": [
-                    "type",
-                    "id"
-                  ],
-                  "properties": {
-                    "type": {
-                      "type": "string",
-                      "description": "Type of the owner (e.g., 'record', 'form')"
-                    },
-                    "id": {
-                      "type": "string",
-                      "description": "Identifier of the owner"
-                    }
-                  }
+          "id": {
+            "type": "string",
+            "description": "Identifier of the attachment"
+          },
+          "owners": {
+            "type": "array",
+            "description": "Array of owner objects for the attachment",
+            "items": {
+              "type": "object",
+              "required": [
+                "type",
+                "id"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "Type of the owner"
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Identifier of the owner"
                 }
               }
             }
@@ -3949,227 +3940,9 @@
                 "description": "Pattern for generating report filenames"
               },
               "config": {
-                "type": "object",
-                "required": [
-                  "size",
-                  "landscape",
-                  "margin_top",
-                  "margin_right",
-                  "margin_bottom",
-                  "margin_left",
-                  "output",
-                  "parameters"
-                ],
-                "description": "Configuration settings for the report",
-                "properties": {
-                  "size": {
-                    "type": "string",
-                    "description": "Page size for the report. Accepts Letter, Legal, Tabloid, Ledger, A0-A8, B0-B10, or custom sizes in WIDTHxHEIGHT format."
-                  },
-                  "landscape": {
-                    "type": "boolean",
-                    "description": "Whether to use landscape orientation"
-                  },
-                  "margin_top": {
-                    "type": "number",
-                    "description": "Top margin in inches"
-                  },
-                  "margin_right": {
-                    "type": "number",
-                    "description": "Right margin in inches"
-                  },
-                  "margin_bottom": {
-                    "type": "number",
-                    "description": "Bottom margin in inches"
-                  },
-                  "margin_left": {
-                    "type": "number",
-                    "description": "Left margin in inches"
-                  },
-                  "output": {
-                    "type": "string",
-                    "enum": [
-                      "html",
-                      "pdf"
-                    ],
-                    "description": "Output format"
-                  },
-                  "hidden_fields": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "The list of fields to be hidden in the report"
-                  },
-                  "field.empty_value": {
-                    "type": "string",
-                    "description": "The value to display for empty fields"
-                  },
-                  "header.enabled": {
-                    "type": "boolean",
-                    "description": "Whether the header is enabled"
-                  },
-                  "header.form.name": {
-                    "type": "boolean",
-                    "description": "Whether the form name is included in the header"
-                  },
-                  "header.record.id": {
-                    "type": "boolean",
-                    "description": "Whether the record ID is included in the header"
-                  },
-                  "footer.enabled": {
-                    "type": "boolean",
-                    "description": "Whether the footer is enabled"
-                  },
-                  "footer.timestamp": {
-                    "type": "boolean",
-                    "description": "Whether the timestamp is included in the footer"
-                  },
-                  "footer.organization_image": {
-                    "type": "boolean",
-                    "description": "Whether the organization image is included in the footer"
-                  },
-                  "footer.organization_info": {
-                    "type": "boolean",
-                    "description": "Whether the organization info is included in the footer"
-                  },
-                  "footer.page_number": {
-                    "type": "boolean",
-                    "description": "Whether the page number is included in the footer"
-                  },
-                  "cover_page.enabled": {
-                    "type": "boolean",
-                    "description": "Whether the cover page is enabled"
-                  },
-                  "cover_page.form.name": {
-                    "type": "boolean",
-                    "description": "Whether the form name is included on the cover page"
-                  },
-                  "cover_page.form.description": {
-                    "type": "boolean",
-                    "description": "Whether the form description is included on the cover page"
-                  },
-                  "cover_page.form.image": {
-                    "type": "boolean",
-                    "description": "Whether the form image is included on the cover page"
-                  },
-                  "cover_page.title": {
-                    "type": "boolean",
-                    "description": "Whether the cover page title is included"
-                  },
-                  "cover_page.timestamp": {
-                    "type": "boolean",
-                    "description": "Whether the timestamp is included on the cover page"
-                  },
-                  "cover_page.image.enabled": {
-                    "type": "boolean",
-                    "description": "Whether images are enabled on the cover page"
-                  },
-                  "cover_page.image.caption": {
-                    "type": "boolean",
-                    "description": "Whether captions are included for images on the cover page"
-                  },
-                  "cover_page.map.enabled": {
-                    "type": "boolean",
-                    "description": "Whether maps are enabled on the cover page"
-                  },
-                  "cover_page.map.repeatables": {
-                    "type": "boolean",
-                    "description": "Whether repeatable items are included on the cover page map"
-                  },
-                  "cover_page.map.type": {
-                    "type": "string",
-                    "description": "The type of map to use on the cover page (e.g., roadmap)"
-                  },
-                  "cover_page.map.size": {
-                    "type": "string",
-                    "description": "The size of the map on the cover page"
-                  },
-                  "cover_page.metadata.enabled": {
-                    "type": "boolean",
-                    "description": "Whether metadata is enabled on the cover page"
-                  },
-                  "cover_page.metadata.created": {
-                    "type": "boolean",
-                    "description": "Whether the creation metadata is included on the cover page"
-                  },
-                  "cover_page.metadata.updated": {
-                    "type": "boolean",
-                    "description": "Whether the update metadata is included on the cover page"
-                  },
-                  "cover_page.metadata.status": {
-                    "type": "boolean",
-                    "description": "Whether the status metadata is included on the cover page"
-                  },
-                  "cover_page.metadata.location": {
-                    "type": "boolean",
-                    "description": "Whether the location metadata is included on the cover page"
-                  },
-                  "cover_page.metadata.project": {
-                    "type": "boolean",
-                    "description": "Whether the project metadata is included on the cover page"
-                  },
-                  "cover_page.metadata.assigned": {
-                    "type": "boolean",
-                    "description": "Whether the assigned metadata is included on the cover page"
-                  },
-                  "parameters": {
-                    "type": "array",
-                    "description": "Array of parameter definitions",
-                    "items": {
-                      "type": "object",
-                      "required": [
-                        "name",
-                        "type",
-                        "required",
-                        "multiple",
-                        "options",
-                        "query",
-                        "default"
-                      ],
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "description": "Parameter name"
-                        },
-                        "label": {
-                          "type": "string",
-                          "description": "Display label for the parameter"
-                        },
-                        "type": {
-                          "type": "string",
-                          "enum": [
-                            "record_id",
-                            "choice_list",
-                            "classification_set",
-                            "project",
-                            "text",
-                            "number",
-                            "date"
-                          ],
-                          "description": "Parameter type"
-                        },
-                        "required": {
-                          "type": "boolean",
-                          "description": "Whether the parameter is required"
-                        },
-                        "multiple": {
-                          "type": "boolean",
-                          "description": "Whether multiple values are allowed"
-                        },
-                        "options": {
-                          "description": "Available options for the parameter. The API accepts an array or null."
-                        },
-                        "query": {
-                          "description": "Query to filter available options. The API accepts a string or null."
-                        },
-                        "default": {
-                          "description": "Default value(s) for the parameter. The API accepts an array or null."
-                        }
-                      }
-                    }
-                  }
-                }
+                "type": "string",
+                "description": "JSON-encoded string containing report configuration settings. The API accepts a JSON string that will be parsed server-side. After parsing, the JSON object contains page size, orientation, margins, output format, and optional parameters.",
+                "example": "{\"size\":\"Letter\",\"landscape\":false,\"margin_top\":0.5,\"margin_right\":0.5,\"margin_bottom\":0.5,\"margin_left\":0.5,\"output\":\"pdf\",\"parameters\":[]}"
               }
             }
           }
@@ -6292,7 +6065,7 @@
             }
           },
           "422": {
-            "description": "Unprocessable Entity \u2014 validation errors (e.g. missing required element properties like disabled, hidden, required). Note: some element validation failures (e.g. YesNoField missing positive/negative) may incorrectly return 500 instead of 422.",
+            "description": "Unprocessable Entity — validation errors (e.g. missing required element properties like disabled, hidden, required). Note: some element validation failures (e.g. YesNoField missing positive/negative) may incorrectly return 500 instead of 422.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6414,7 +6187,7 @@
             }
           },
           "422": {
-            "description": "Unprocessable Entity \u2014 validation errors",
+            "description": "Unprocessable Entity — validation errors",
             "content": {
               "application/json": {
                 "schema": {
@@ -7672,6 +7445,16 @@
                 }
               }
             }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptySuccessResponse"
+                }
+              }
+            }
           }
         },
         "deprecated": false
@@ -7961,6 +7744,16 @@
                 }
               }
             }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptySuccessResponse"
+                }
+              }
+            }
           }
         },
         "deprecated": false
@@ -8236,6 +8029,16 @@
                 }
               }
             }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptySuccessResponse"
+                }
+              }
+            }
           }
         },
         "deprecated": false
@@ -8396,6 +8199,9 @@
                 }
               }
             }
+          },
+          "204": {
+            "description": "No Content"
           }
         },
         "deprecated": false
@@ -11942,6 +11748,16 @@
                 }
               }
             }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmptySuccessResponse"
+                }
+              }
+            }
           }
         },
         "deprecated": false
@@ -13701,6 +13517,32 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "report_template": {
+                      "type": "object",
+                      "properties": {
+                        "errors": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "deprecated": false
@@ -13790,6 +13632,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Unprocessable Entity – validation error"
           }
         },
         "deprecated": false


### PR DESCRIPTION
Contract harness findings from app-mcp live runs:

- **Report templates POST**: add 422 response for validation errors
- **Report templates config**: document as JSON string (API parses server-side)
- **Attachment finalize**: flat request body (no `attachment` wrapper)
- **Choice lists POST**: add 201 response (live returns 201 on create)
- **Classification sets POST**: add 201 response
- **Projects POST**: add 201 response
- **Projects DELETE**: add 204 response (No Content)
- **Attachments DELETE**: add 200 response (live returns 200)

These findings were discovered by the app-mcp contract harness running against production.